### PR TITLE
fix(v6.7.2): 修复安装包 schemas 和 CLI 导入

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -100,12 +100,13 @@ git commit -m "chore(v${VERSION}): 版本号更新到 ${VERSION}"
 git tag -a "v${VERSION}" -m "v${VERSION}"
 echo "  ✓ 已提交并创建 tag v${VERSION}"
 
-# 9. 构建 + 发布 PyPI
-echo "[9/10] 构建并发布到 PyPI..."
+# 9. 构建 + 发布包验收 + 发布 PyPI
+echo "[9/10] 构建、验收并发布到 PyPI..."
 rm -rf "$RODSKI_DIR/dist/"
 python3 -m build "$RODSKI_DIR/"
+"$PROJECT_ROOT/scripts/release_check.sh" "$VERSION"
 python3 -m twine upload "$RODSKI_DIR/dist/rodski-${VERSION}"*
-echo "  ✓ 已发布到 PyPI"
+echo "  ✓ 已通过发布包验收并发布到 PyPI"
 
 # 10. 推送远端
 echo "[10/10] 推送到 GitHub 和 GitLab..."

--- a/rodski/cli_main.py
+++ b/rodski/cli_main.py
@@ -6,12 +6,15 @@ import traceback
 from pathlib import Path
 
 if __package__ in (None, ""):
-    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-    from rodski.rodski_cli import run, model, config, log, report, profile, docs, capabilities, data, init, plan
-else:
-    from .rodski_cli import run, model, config, log, report, profile, docs, capabilities, data, init, plan
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from rodski import __version__ as VERSION
+from rodski_cli import run, model, config, log, report, profile, docs, capabilities, data, init, plan
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    VERSION = version("rodski")
+except PackageNotFoundError:
+    VERSION = "dev"
 
 
 def format_error(e, verbose=False):

--- a/rodski/pyproject.toml
+++ b/rodski/pyproject.toml
@@ -4,9 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rodski"
-version = "6.7.1"
+version = "6.7.2"
 description = "RodSki 关键字驱动自动化测试框架"
 requires-python = ">=3.8"
+
+[project.scripts]
+rodski = "rodski_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -23,11 +26,15 @@ include = [
     "reviewers*",
     "rodski_cli*",
     "rodski_docs*",
+    "schemas*",
     "ui*",
     "utils*",
     "vision*",
 ]
-exclude = ["tests*", "docs*", "examples*", "scripts*", "schemas*"]
+exclude = ["tests*", "docs*", "examples*", "scripts*"]
+
+[tool.setuptools.package-data]
+schemas = ["*.xsd"]
 
 [tool.black]
 line-length = 120

--- a/rodski/pyproject.toml
+++ b/rodski/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rodski"
-version = "6.7.2"
+version = "6.7.3"
 description = "RodSki 关键字驱动自动化测试框架"
 requires-python = ">=3.8"
 

--- a/rodski/rodski_cli/__init__.py
+++ b/rodski/rodski_cli/__init__.py
@@ -3,7 +3,12 @@ import sys
 import argparse
 from . import run, model, config, log, report, docs, data, init, plan
 
-from rodski import __version__ as VERSION
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    VERSION = version("rodski")
+except PackageNotFoundError:
+    VERSION = "dev"
 
 def main():
     parser = argparse.ArgumentParser(

--- a/rodski/rodski_cli/capabilities.py
+++ b/rodski/rodski_cli/capabilities.py
@@ -17,14 +17,19 @@ def setup_parser(subparsers):
 
 def handle(args):
     """输出 JSON 格式的 rodski 能力清单。"""
-    from rodski import __version__
-    from rodski.core.keyword_engine import KeywordEngine
-    from rodski.core.driver_factory import DriverFactory
-    from rodski.core.model_parser import VALID_LOCATOR_TYPES
-    from rodski.core.xml_schema_validator import SCHEMA_FILES
+    from importlib.metadata import PackageNotFoundError, version
+    from core.keyword_engine import KeywordEngine
+    from core.driver_factory import DriverFactory
+    from core.model_parser import VALID_LOCATOR_TYPES
+    from core.xml_schema_validator import SCHEMA_FILES
+
+    try:
+        framework_version = version("rodski")
+    except PackageNotFoundError:
+        framework_version = "dev"
 
     capabilities = {
-        "version": __version__,
+        "version": framework_version,
         "supported_keywords": list(KeywordEngine.SUPPORTED),
         "compat_keywords": ["check"],
         "locator_types": list(VALID_LOCATOR_TYPES),

--- a/rodski/rodski_cli/config.py
+++ b/rodski/rodski_cli/config.py
@@ -19,7 +19,7 @@ def setup_parser(subparsers):
 
 
 def handle(args):
-    from ..core.config_manager import ConfigManager
+    from core.config_manager import ConfigManager
 
     manager = ConfigManager()
 

--- a/rodski/rodski_cli/data.py
+++ b/rodski/rodski_cli/data.py
@@ -40,7 +40,7 @@ def setup_parser(subparsers):
 
 def _load(module: str):
     try:
-        from ..core.data_table_parser import DataTableParser
+        from core.data_table_parser import DataTableParser
     except ImportError:
         from core.data_table_parser import DataTableParser
     data_dir = Path(module) / "data"
@@ -103,7 +103,7 @@ def handle(args):
 
     elif cmd == "validate":
         try:
-            from ..core.exceptions import DataParseError
+            from core.exceptions import DataParseError
         except ImportError:
             from core.exceptions import DataParseError
         try:

--- a/rodski/rodski_cli/data_import.py
+++ b/rodski/rodski_cli/data_import.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 try:
-    from ..core.sqlite_schema import SQLITE_DDL
+    from core.sqlite_schema import SQLITE_DDL
 except ImportError:
     from core.sqlite_schema import SQLITE_DDL
 

--- a/rodski/rodski_cli/explain.py
+++ b/rodski/rodski_cli/explain.py
@@ -42,9 +42,9 @@ def _resolve_module_dir(case_path: Path) -> Path:
 
 
 def handle(args):
-    from ..core.test_case_explainer import TestCaseExplainer
-    from ..core.model_parser import ModelParser
-    from ..core.data_table_parser import DataTableParser
+    from core.test_case_explainer import TestCaseExplainer
+    from core.model_parser import ModelParser
+    from core.data_table_parser import DataTableParser
 
     raw_path = Path(args.case)
     if not raw_path.exists():

--- a/rodski/rodski_cli/init.py
+++ b/rodski/rodski_cli/init.py
@@ -4,7 +4,7 @@ import sqlite3
 from pathlib import Path
 
 try:
-    from ..core.sqlite_schema import SQLITE_DDL
+    from core.sqlite_schema import SQLITE_DDL
 except ImportError:
     from core.sqlite_schema import SQLITE_DDL
 

--- a/rodski/rodski_cli/model.py
+++ b/rodski/rodski_cli/model.py
@@ -20,7 +20,7 @@ def setup_parser(subparsers):
 
 
 def handle(args):
-    from ..data.model_manager import ModelManager
+    from data.model_manager import ModelManager
 
     manager = ModelManager()
 

--- a/rodski/rodski_cli/plan.py
+++ b/rodski/rodski_cli/plan.py
@@ -342,9 +342,9 @@ def _handle_validate(args):
 
 def _handle_preview(args):
     try:
-        from ..core.plan_parser import PlanParser
-        from ..core.case_parser import CaseParser
-        from ..core.test_plan_selection import TestPlanSelection
+        from core.plan_parser import PlanParser
+        from core.case_parser import CaseParser
+        from core.test_plan_selection import TestPlanSelection
     except ImportError:
         from core.plan_parser import PlanParser
         from core.case_parser import CaseParser
@@ -404,8 +404,8 @@ def _handle_create(args):
     # --from-tag / --from-group: populate cases from selector
     if args.from_tag or args.from_group:
         try:
-            from ..core.case_parser import CaseParser
-            from ..core.test_plan_selection import compile_from_selector
+            from core.case_parser import CaseParser
+            from core.test_plan_selection import compile_from_selector
         except ImportError:
             from core.case_parser import CaseParser
             from core.test_plan_selection import compile_from_selector

--- a/rodski/rodski_cli/profile.py
+++ b/rodski/rodski_cli/profile.py
@@ -1,9 +1,9 @@
 """性能分析命令"""
 import sys
 from pathlib import Path
-from ..core.profiler import Profiler
-from ..core.performance import set_profiler
-from ..core.task_executor import TaskExecutor
+from core.profiler import Profiler
+from core.performance import set_profiler
+from core.task_executor import TaskExecutor
 
 
 def setup_parser(subparsers):

--- a/rodski/rodski_cli/run.py
+++ b/rodski/rodski_cli/run.py
@@ -193,7 +193,7 @@ def handle(args):
     plan_path_str = str(plan_path) if plan_path else None
     try:
         try:
-            from ..core.test_plan_selection import check_plan_selector_conflict
+            from core.test_plan_selection import check_plan_selector_conflict
         except ImportError:
             from core.test_plan_selection import check_plan_selector_conflict
         check_plan_selector_conflict(plan_path_str, selector_filters)
@@ -263,10 +263,10 @@ def _handle_dry_run(
 ) -> int:
     """验证用例可执行性但不实际执行"""
     try:
-        from ..core.case_parser import CaseParser
-        from ..core.model_parser import ModelParser
-        from ..core.plan_parser import PlanParser
-        from ..core.test_plan_selection import TestPlanSelection, compile_from_selector
+        from core.case_parser import CaseParser
+        from core.model_parser import ModelParser
+        from core.plan_parser import PlanParser
+        from core.test_plan_selection import TestPlanSelection, compile_from_selector
     except ImportError:
         from core.case_parser import CaseParser
         from core.model_parser import ModelParser
@@ -428,11 +428,11 @@ def _print_plan_dry_run_selection(plan, selection) -> None:
 def _handle_execute(case_path: Path, module_dir: Path, args, plan_path: Optional[Path] = None, selector_filters: Optional[Dict[str, Any]] = None) -> int:
     """实际执行测试用例"""
     try:
-        from ..core.ski_executor import SKIExecutor
-        from ..core.config_manager import ConfigManager
-        from ..drivers.playwright_driver import PlaywrightDriver
-        from ..core.json_formatter import JSONFormatter
-        from ..core.runtime_control import RuntimeCommandQueue
+        from core.ski_executor import SKIExecutor
+        from core.config_manager import ConfigManager
+        from drivers.playwright_driver import PlaywrightDriver
+        from core.json_formatter import JSONFormatter
+        from core.runtime_control import RuntimeCommandQueue
     except ImportError:
         from core.ski_executor import SKIExecutor
         from core.config_manager import ConfigManager

--- a/rodski/rodski_cli/stats.py
+++ b/rodski/rodski_cli/stats.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
 
-from ..core.statistics_collector import StatisticsCollector
+from core.statistics_collector import StatisticsCollector
 
 
 def setup_parser(subparsers):

--- a/rodski/schemas/__init__.py
+++ b/rodski/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""RodSki XML schema package."""

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# RodSki wheel 发布包验收脚本
+# 用法: scripts/release_check.sh <version>
+# 示例: scripts/release_check.sh 6.7.3
+
+set -euo pipefail
+
+VERSION=${1:-}
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RODSKI_DIR="$PROJECT_ROOT/rodski"
+DIST_DIR="$RODSKI_DIR/dist"
+WHEEL="$DIST_DIR/rodski-${VERSION}-py3-none-any.whl"
+SDIST="$DIST_DIR/rodski-${VERSION}.tar.gz"
+TMP_DIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [ -z "$VERSION" ]; then
+    echo "用法: scripts/release_check.sh <version>"
+    exit 1
+fi
+
+echo "=== RodSki v${VERSION} 发布包验收 ==="
+
+# 1. 构建产物存在性
+if [ ! -f "$WHEEL" ]; then
+    echo "错误: wheel 不存在: $WHEEL"
+    exit 1
+fi
+if [ ! -f "$SDIST" ]; then
+    echo "错误: sdist 不存在: $SDIST"
+    exit 1
+fi
+
+echo "[1/5] 构建产物存在"
+
+# 2. wheel 内容完整性
+REQUIRED_FILES=(
+    "core/keyword_engine.py"
+    "core/xml_schema_validator.py"
+    "data/data_resolver.py"
+    "data/builtin_functions.py"
+    "drivers/__init__.py"
+    "api/__init__.py"
+    "llm/__init__.py"
+    "report/__init__.py"
+    "vision/__init__.py"
+    "rodski_cli/__init__.py"
+    "schemas/model.xsd"
+    "schemas/case.xsd"
+    "schemas/data.xsd"
+    "schemas/result.xsd"
+)
+
+for file in "${REQUIRED_FILES[@]}"; do
+    if ! python3 -m zipfile -l "$WHEEL" | grep -q "$file"; then
+        echo "错误: wheel 缺少必要文件: $file"
+        exit 1
+    fi
+done
+
+echo "[2/5] wheel 内容完整"
+
+# 3. 干净 venv 安装
+python3 -m venv "$TMP_DIR/venv"
+source "$TMP_DIR/venv/bin/activate"
+pip install "$WHEEL" --quiet
+
+echo "[3/5] 干净 venv 安装成功"
+
+# 4. 安装态 import + schemas 校验
+python - <<'PY'
+import importlib
+
+modules = [
+    "core",
+    "data",
+    "drivers",
+    "api",
+    "llm",
+    "report",
+    "vision",
+    "rodski_cli",
+]
+for module in modules:
+    importlib.import_module(module)
+
+from core.xml_schema_validator import schemas_directory
+schema_dir = schemas_directory()
+assert schema_dir.exists(), f"schemas 目录不存在: {schema_dir}"
+for name in ["model.xsd", "case.xsd", "data.xsd", "result.xsd"]:
+    assert (schema_dir / name).exists(), f"缺少 XSD: {name}"
+
+from data.builtin_functions import call_function
+assert call_function("random", ["int", "4"]).isdigit()
+
+from data.data_resolver import DataResolver
+resolved = DataResolver().resolve_with_return("user_${random(int, 4)}")
+assert resolved.startswith("user_"), resolved
+assert resolved[5:].isdigit(), resolved
+
+print("install imports ok")
+PY
+
+echo "[4/5] 安装态模块和 schemas 验证通过"
+
+# 5. CLI 验证
+rodski --version | grep -q "$VERSION"
+
+echo "[5/5] CLI 验证通过"
+
+deactivate
+
+echo "=== RodSki v${VERSION} 发布包验收通过 ==="


### PR DESCRIPTION
## Summary
- 修复 v6.7.1 wheel 安装后 `rodski_cli` 导入失败的问题：移除对缺失 `rodski` 顶层包的依赖，改用 package metadata 获取版本
- 将 `schemas/*.xsd` 纳入 wheel 包，修复安装态 `ModelParser` / XSD 校验找不到 schema 的问题
- 增加 `rodski` console script 入口，支持安装后直接 `rodski --version`

## Test plan
- [x] `cd rodski && python3 -m pytest tests/unit/test_cli_ux.py tests/unit/test_builtin_functions.py tests/unit/test_data_resolver.py -q` → 79 passed
- [x] `python3 -m build rodski/` 成功生成 `rodski-6.7.2` wheel/sdist
- [x] 干净 venv 安装 wheel 后验证：`rodski --version`、`import rodski_cli`、`core.xml_schema_validator.schemas_directory()/model.xsd`、`DataResolver().resolve_with_return('x_${random(int, 4)}')`

## Notes
- 本 PR 只修复打包/安装态问题，不改运行时业务逻辑
- 版本号从 6.7.1 bump 到 6.7.2，准备作为补丁版本发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)